### PR TITLE
Allow flashes etc of more than one color

### DIFF
--- a/BoulderLogbook/EntryForm/EntryForm.swift
+++ b/BoulderLogbook/EntryForm/EntryForm.swift
@@ -141,7 +141,7 @@ struct EntryForm {
                 }
 
             case let .attemptStepperChanged(value, grade):
-                if value > state.attempts.count {
+                if value > state.attempts.count(for: grade) {
                     state.attempts.append(
                         Top(grade: grade.id, isAttempt: true)
                     )
@@ -152,7 +152,7 @@ struct EntryForm {
                 }
 
             case let .flashStepperChanged(value, grade):
-                if value > state.flashs.count {
+                if value > state.flashs.count(for: grade) {
                     state.flashs.append(
                         Top(grade: grade.id, wasFlash: true)
                     )
@@ -163,7 +163,7 @@ struct EntryForm {
                 }
 
             case let .onsightStepperChanged(value, grade):
-                if value > state.onsights.count {
+                if value > state.onsights.count(for: grade) {
                     state.onsights.append(
                         Top(grade: grade.id, wasOnsight: true)
                     )


### PR DESCRIPTION
When I started using this app yesterday I realized quickly that you cannot track flashes, onsights, or attempts from more then one difficulty setting. I could for instance record flashes for difficulty `5`, but not any other color.

So I took a look at the code and found that the `EntryForm`, when trying to apply the update sent by the view controller, doesn't filter by grade. It instead falls through to the `else` branch, attempting to remove a flash (and finding none).

This pull request should fix this issue.
Thanks for building this! It's fun to use while bouldering!